### PR TITLE
vfs: 在教師資訊中，將 msid=2 也顯示為「其他授課教師」

### DIFF
--- a/ceiba_dl/config.py
+++ b/ceiba_dl/config.py
@@ -197,6 +197,7 @@ class Config:
             'attr_course_teachers_tr_msid': '教師類別',
             'value_course_teachers_tr_msid_0': '主要授課教師',
             'value_course_teachers_tr_msid_1': '其他授課教師',
+            'value_course_teachers_tr_msid_2': '其他授課教師',
             'attr_course_teachers_cname': '中文姓名',
             'attr_course_teachers_ename': '英文姓名',
             'attr_course_teachers_email': '電子郵件',

--- a/ceiba_dl/vfs.py
+++ b/ceiba_dl/vfs.py
@@ -2997,6 +2997,9 @@ class CourseTeacherInfoDirectory(Directory):
             elif teacher['tr_msid'] == '1':
                 teacher_file.add(s['attr_course_teachers_tr_msid'],
                     s['value_course_teachers_tr_msid_1'], 'tr_msid')
+            elif teacher['tr_msid'] == '2':
+                teacher_file.add(s['attr_course_teachers_tr_msid'],
+                    s['value_course_teachers_tr_msid_2'], 'tr_msid')
             else:
                 assert False
 


### PR DESCRIPTION
嘗試列出「心理與神經資訊學」的教師資訊時發生AssertionError
```
$ ./ceiba-dl ls /課程/104-1/心理與神經資訊學/教師資訊
Traceback (most recent call last):
  File "./ceiba-dl", line 243, in <module>
    exit(0 if args.func(args, config) else 1)
  File "./ceiba-dl", line 158, in run_ls
    lser.run(sys.stdout, path)
  File "/home/yen/Projects/ceiba-dl/ceiba_dl/__init__.py", line 433, in run
    self.print_file(output, path, self.recursive)
  File "/home/yen/Projects/ceiba-dl/ceiba_dl/__init__.py", line 397, in print_file
    node = self.vfs.open(path)
  File "/home/yen/Projects/ceiba-dl/ceiba_dl/vfs.py", line 39, in open
    work.fetch()
  File "/home/yen/Projects/ceiba-dl/ceiba_dl/vfs.py", line 3001, in fetch
    assert False
AssertionError
```

API回傳的結果中，這位老師的msid為2。我登入CEIBA App查看，發現此門課的教師有三個，名字皆為同一人（黃從仁），第一個標示為主要授課老師，另外兩個標示為其他授課教師，因此我推測只有0為主要授課老師。